### PR TITLE
Catch PlatformException on checkForUpdate method

### DIFF
--- a/lib/in_app_update.dart
+++ b/lib/in_app_update.dart
@@ -56,19 +56,23 @@ class InAppUpdate {
   /// Returns [AppUpdateInfo], which can be used to decide if
   /// [startFlexibleUpdate] or [performImmediateUpdate] should be called.
   static Future<AppUpdateInfo> checkForUpdate() async {
-    final result = await _channel.invokeMethod('checkForUpdate');
+    try {
+      final result = await _channel.invokeMethod('checkForUpdate');
 
-    return AppUpdateInfo(
-      updateAvailability:
-          UpdateAvailability.values.firstWhere((element) => element.value == result['updateAvailability']),
-      immediateUpdateAllowed: result['immediateAllowed'],
-      flexibleUpdateAllowed: result['flexibleAllowed'],
-      availableVersionCode: result['availableVersionCode'],
-      installStatus: InstallStatus.values.firstWhere((element) => element.value == result['installStatus']),
-      packageName: result['packageName'],
-      clientVersionStalenessDays: result['clientVersionStalenessDays'],
-      updatePriority: result['updatePriority'],
-    );
+      return AppUpdateInfo(
+        updateAvailability:
+            UpdateAvailability.values.firstWhere((element) => element.value == result['updateAvailability']),
+        immediateUpdateAllowed: result['immediateAllowed'],
+        flexibleUpdateAllowed: result['flexibleAllowed'],
+        availableVersionCode: result['availableVersionCode'],
+        installStatus: InstallStatus.values.firstWhere((element) => element.value == result['installStatus']),
+        packageName: result['packageName'],
+        clientVersionStalenessDays: result['clientVersionStalenessDays'],
+        updatePriority: result['updatePriority'],
+      );
+    } on PlatformException catch (e) {
+      throw e;
+    }
   }
 
   /// Performs an immediate update that is entirely handled by the Play API.


### PR DESCRIPTION
Android Studio and VS Code throws handled exceptions as uncaught when there is no an explicit Try Catch call. More information in:

https://github.com/flutter/flutter/issues/33427