### PR TITLE
Catch PlatformException on checkForUpdate method 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_version = '1.7.10'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '1.7.10'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {

--- a/lib/in_app_update.dart
+++ b/lib/in_app_update.dart
@@ -56,26 +56,29 @@ class InAppUpdate {
   /// Returns [AppUpdateInfo], which can be used to decide if
   /// [startFlexibleUpdate] or [performImmediateUpdate] should be called.
   static Future<AppUpdateInfo> checkForUpdate() async {
-    final result = await _channel.invokeMethod('checkForUpdate');
-
-    return AppUpdateInfo(
-      updateAvailability: UpdateAvailability.values.firstWhere(
-          (element) => element.value == result['updateAvailability']),
-      immediateUpdateAllowed: result['immediateAllowed'],
-      immediateAllowedPreconditions: result['immediateAllowedPreconditions']
-          ?.map<int>((e) => e as int)
-          .toList(),
-      flexibleUpdateAllowed: result['flexibleAllowed'],
-      flexibleAllowedPreconditions: result['flexibleAllowedPreconditions']
-          ?.map<int>((e) => e as int)
-          .toList(),
-      availableVersionCode: result['availableVersionCode'],
-      installStatus: InstallStatus.values
-          .firstWhere((element) => element.value == result['installStatus']),
-      packageName: result['packageName'],
-      clientVersionStalenessDays: result['clientVersionStalenessDays'],
-      updatePriority: result['updatePriority'],
-    );
+    try {
+      final result = await _channel.invokeMethod('checkForUpdate');
+      return AppUpdateInfo(
+        updateAvailability: UpdateAvailability.values.firstWhere(
+            (element) => element.value == result['updateAvailability']),
+        immediateUpdateAllowed: result['immediateAllowed'],
+        immediateAllowedPreconditions: result['immediateAllowedPreconditions']
+            ?.map<int>((e) => e as int)
+            .toList(),
+        flexibleUpdateAllowed: result['flexibleAllowed'],
+        flexibleAllowedPreconditions: result['flexibleAllowedPreconditions']
+            ?.map<int>((e) => e as int)
+            .toList(),
+        availableVersionCode: result['availableVersionCode'],
+        installStatus: InstallStatus.values
+            .firstWhere((element) => element.value == result['installStatus']),
+        packageName: result['packageName'],
+        clientVersionStalenessDays: result['clientVersionStalenessDays'],
+        updatePriority: result['updatePriority'],
+      );
+    } on PlatformException catch (e) {
+      throw e;
+    }
   }
 
   /// Performs an immediate update that is entirely handled by the Play API.


### PR DESCRIPTION
Android Studio and VS Code throws handled exceptions as uncaught when there is no an explicit Try Catch call in some cases. For example:

https://github.com/flutter/flutter/issues/33427