### PR TITLE
Match Kotlin jvm compatibility to java compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,6 +37,15 @@ android {
         disable 'InvalidPackage'
     }
     namespace "de.ffuf.in_app_update"
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
**Fixes the following error when using AGP 8:**

> 1: Task failed with an exception.
> -----------
> * What went wrong:
> Execution failed for task ':in_app_update:compileDebugKotlin'.
> > 'compileDebugJavaWithJavac' task (current target is 1.8) and 'compileDebugKotlin' task (current target is 17) jvm target compatibility should be set to the same Java version.
>   Consider using JVM toolchain: https://kotl.in/gradle/jvm/toolchain

I assume this was just a warning before and is now treated as an error.