### PR TITLE
Migrate to Flutter's built-in Kotlin (Flutter 3.44+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.0
+- **Breaking:** requires Flutter 3.44 / Dart 3.12 or newer.
+- Migrate to Flutter's built-in Kotlin: the plugin no longer applies the Kotlin Gradle Plugin or declares its classpath, and uses the `kotlin { compilerOptions }` DSL instead of `kotlinOptions` (fixes #137)
+
 ## 4.2.5
 - Update dependencies (thanks @ivan-horchakov)
  

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'de.ffuf.in_app_update'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '2.2.10'
+    ext.kotlin_version = '2.2.20'
     repositories {
         google()
         mavenCentral()
@@ -10,7 +10,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:8.13.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -22,8 +21,10 @@ allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
+// Kotlin is provided by Flutter's built-in Kotlin support (Flutter 3.44+), so
+// the plugin no longer applies the Kotlin Gradle Plugin itself. See:
+// https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors
 android {
     if (project.android.hasProperty("namespace")) {
         namespace 'de.ffuf.in_app_update'
@@ -34,10 +35,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
     }
 
     sourceSets {
@@ -51,6 +48,12 @@ android {
 
     lintOptions {
         disable 'InvalidPackage'
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
     }
 }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
     id "dev.flutter.flutter-gradle-plugin"
 }
 
@@ -32,10 +31,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
@@ -59,6 +54,12 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
     }
 }
 

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,2 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
+android.builtInKotlin=true
+android.newDsl=true

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -20,7 +20,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.13.0" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.10" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ':app'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: in_app_update
 description: Enables In App Updates on Android using the official Android APIs.
-version: 4.2.5
+version: 5.0.0
 homepage: https://jonasbark.de
 repository: https://github.com/jonasbark/flutter_in_app_update
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
-  flutter: ">=1.20.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Closes #137

Flutter 3.44 requires plugin authors to rely on Flutter's built-in Kotlin instead of applying the Kotlin Gradle Plugin themselves ([migration guide](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors)). This migrates both the plugin and the example app.

## Plugin (`android/build.gradle`)
- Removed `apply plugin: 'kotlin-android'` and the `org.jetbrains.kotlin:kotlin-gradle-plugin` classpath — Kotlin is now provided by Flutter's built-in Kotlin support.
- Replaced the deprecated `kotlinOptions { jvmTarget = '1.8' }` block with `kotlin { compilerOptions { jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8 } }` (kept `JVM_1_8` to preserve the plugin's existing Java 8 target).
- Bumped KGP `2.2.10 → 2.2.20` (the minimum Flutter now recommends).

## Example app (`example/android/`)
- Migrated to built-in Kotlin per the [for-app-developers guide](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers): removed `kotlin-android` from the app's `plugins {}` block, dropped `kotlinOptions`, and switched to the `kotlin { compilerOptions }` DSL.
- Set `android.builtInKotlin=true` and `android.newDsl=true` in `gradle.properties` so `flutter build` no longer keeps re-writing the `=false` opt-out flags.
- Bumped the KGP declaration in `settings.gradle` to `2.2.20`.

## Version
- **Breaking:** bumped to `5.0.0`; `pubspec.yaml` now requires `flutter: ">=3.44.0"` / `sdk: ^3.12.0`.

## Note: `org.jetbrains.kotlin.android` kept in example `settings.gradle`
The for-app-developers guide suggests removing that plugin declaration entirely, but I intentionally **kept** it (bumped to `2.2.20`). On AGP 8.13 (what the example uses), built-in Kotlin still sources the Kotlin **compiler** version from that declaration. Removing it makes the compiler fall back to `2.0.0`, which is incompatible with the `2.2.20` stdlib and fails the build with `Module was compiled with an incompatible version of Kotlin`. The guide's "remove it" step only applies once the project is on AGP 9 with bundled Kotlin.

## Verification
Verified end-to-end against Flutter 3.45.0 / Dart 3.12.1 / Java 21 / AGP 8.13:
- `flutter build apk --debug` on the example → builds successfully.
- Confirmed `flutter build` no longer re-adds `builtInKotlin=false` / `newDsl=false`.
- Confirmed the plugin compiles for consumers whether or not their own app has migrated (built `builtInKotlin` both `true` and `false`).
- The "applies the Kotlin Gradle Plugin" warnings and the KGP-version warning are gone.

Remaining (out of scope, pre-existing): Flutter warns that Gradle `8.13.0` will soon be unsupported (wants ≥ `8.14.0`) — a wrapper-version bump unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
